### PR TITLE
A temporary workaround, for the access restriction issue on PRs from forked repos.

### DIFF
--- a/.github/workflows/feature-build.yml
+++ b/.github/workflows/feature-build.yml
@@ -39,19 +39,8 @@ jobs:
       - name: Execute Unit Tests
         run: npm run test
 
-      # set the only_changed_files to true on PR based builds, otherwise show full coverage
-      - name: Produce Coverage report
-        uses: 5monkeys/cobertura-action@b3d1f4899a5f2d30adc2a13ac2abcd9f72e1fe66 # pin@master
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@v2
         with:
+          name: coverage
           path: coverage/cobertura-coverage.xml
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          only_changed_files: ${{github.base_ref != null}}
-          show_line: true
-          show_branch: true
-          minimum_coverage: 90
-
-      - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@c35654669e40ece974c8835211c2e8ad9c802df0 # pin@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -1,0 +1,50 @@
+#
+# This workflow will run post build quality checks
+# and is invoked when the "Build - PR" workflow finishes.
+#
+name: Quality Checks
+
+on:
+  workflow_run:
+    workflows: ["Build - PR"]
+    types:
+      - completed
+
+jobs:
+  perform-quality-checks:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+
+    steps:
+
+      - name: Checkout Codebase
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_commit.id }}
+
+      - name: Download Coverage Artifacts
+        uses: dawidd6/action-download-artifact@891cccee4b25d3306cf5edafa174ddc1d969871f
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          commit: ${{ github.event.workflow_run.head_commit.id }}
+          name: coverage
+          path: coverage
+
+      # set the only_changed_files to true on PR based builds, otherwise show full coverage
+      - name: Produce Coverage report
+        uses: bijujoseph/cobertura-action@master # temporary
+        with:
+          path: coverage/cobertura-coverage.xml
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          only_changed_files: ${{github.base_ref != null}}
+          show_line: true
+          show_branch: true
+          minimum_coverage: 90
+
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@c35654669e40ece974c8835211c2e8ad9c802df0 # pin@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION

## Description
Pull request workflows (event `pull_request`) raised from repository forks get read-only token. This causes the workflows involving `cobertura-action` to fail, due to lack of permission. 
> `Error: Resource not accessible by integration

Actions team recently introduced `pull_request_target`, but that poses additional security risks. To mitigate that, they recommend to split these workflows, a well-written recipe can be found in [2](https://securitylab.github.com/research/github-actions-preventing-pwn-requests)

Certainly, `cobertura-action` accepts `pull_request_number` parameter, but that will put the onus on the workflow author. So, in order to keep things simple, it is better to encapsulate the PR identification logic within this action for workflow_run events.  

_References_: 
- 1 https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/
- 2 https://securitylab.github.com/research/github-actions-preventing-pwn-requests

## Motivation and Context
There are three ways to solve this issue. 
 1. Use a Personal Access token for `cobertura-action`. 
 2. Use `pull_request_target` event. 
 3. Split the workflow in such a way that all the basic PR checks happen in the primary flow(lint, test, coverage) and sonar-cube, coverage-reporting happens in the secondary workflow. 
 
I am leaning towards the 3rd option, as it is more secure and reliable in the long run. 

## How Has This Been Tested?
Executed these in a test repo workflow and made sure that it works for both internal and external PRs. 

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
