### PR TITLE
Add support for redactions via regular expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ logLevel | All log messages at this level or higher will be logged. `none` effec
 logTimestamps | Add timestamps to log entries | `true` or `false` | `true`
 logColorize | If `true`, log messages will be sent colorized (most valuable when logging to the `console`) | `true` or `false` | `false`
 redactKeys | An array of keys to scrub from the log metadata | an array of lowercase strings | ``['email', 'firstname', 'lastname', 'password', 'ptan', 'tin', 'userid', 'username']``
+redactRegexes | An array of regular expressions representing string values to scrub | an array of regular expressions (string or `RegExp`) | ``[]``
 maxDays | The maximum number of days to keep logs for. | A number, in days | 0 (No deletion)
 rotationMaxsize | The max size the log file should reach before it is rotated. | a size, in bytes. For example, 1M = 1000000. Or 'none' to never rotate logs | 50000000 (50M)
 splunkSettings | Adding the Splunk configuration settings will add Splunk http transport via the [winston-splunk-httplogger](https://github.com/adrianhall/winston-splunk-httplogger) package | `object` | `undefined`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qpp-shared-logger-node",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "qpp-shared-logger-node",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "UNLICENSED",
       "dependencies": {
         "morgan": "^1.10.0",
@@ -1165,9 +1165,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001228",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
-      "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
+      "version": "1.0.30001297",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001297.tgz",
+      "integrity": "sha512-6bbIbowYG8vFs/Lk4hU9jFt7NknGDleVAciK916tp6ft1j+D//ZwwL6LbF1wXMQ32DMSjeuUV8suhh6dlmFjcA==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -6577,9 +6577,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001228",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
-      "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
+      "version": "1.0.30001297",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001297.tgz",
+      "integrity": "sha512-6bbIbowYG8vFs/Lk4hU9jFt7NknGDleVAciK916tp6ft1j+D//ZwwL6LbF1wXMQ32DMSjeuUV8suhh6dlmFjcA==",
       "dev": true
     },
     "caseless": {

--- a/src/options.ts
+++ b/src/options.ts
@@ -19,6 +19,7 @@ export interface Options {
     };
     datePattern?: string;
     redactKeys?: string[];
+    redactRegexes?: Array<string | RegExp>;
     maxDays?: number;
     rotationMaxsize?: number | string;
     accessLog?: {

--- a/src/scrubber.ts
+++ b/src/scrubber.ts
@@ -22,12 +22,13 @@ const defaultRedactKeys = [
 ];
 
 export class Scrubber {
-    blacklist = [];
+    private readonly blacklist: string[] = [];
+    private readonly regexesBlacklist: Array<string | RegExp> = [];
     // A winston Formatter that removes all meta
     // See https://github.com/winstonjs/winston/blob/HEAD/UPGRADE-3.0.md#rewriters for upgrade info
     format = winston.format((info) => this.scrub(info));
 
-    constructor(redactKeys: string[]) {
+    constructor(redactKeys: string[], regexesBlacklist?: Array<string | RegExp>) {
         // merge with defaults
         this.blacklist = [
             ...new Set([
@@ -35,6 +36,7 @@ export class Scrubber {
                 ...defaultRedactKeys,
             ]),
         ];
+        this.regexesBlacklist = regexesBlacklist ?? [];
     }
 
     scrub(logEntry) {
@@ -42,6 +44,13 @@ export class Scrubber {
         const redacted = _.cloneDeepWith(logEntry, (value, key) => {
             if (_.isString(key) && this.blacklist.includes(key.toLowerCase())) {
                 return '[REDACTED]';
+            }
+            if (_.isString(value) && this.regexesBlacklist) {
+                this.regexesBlacklist.forEach((redaction) => {
+                    const regex = new RegExp(redaction);
+                    value = value.replace(new RegExp(regex.source, regex.flags + 'g'), '[REDACTED]');
+                })
+                return value;
             }
         });
 

--- a/test/scrubber.ts
+++ b/test/scrubber.ts
@@ -5,7 +5,7 @@ import { Scrubber } from '../src/scrubber';
 
 describe('scrubber', function () {
     // initialize scrubber
-    const scrubber = new Scrubber(['password', 'firstname', 'CamelCaseKey']);
+    const scrubber = new Scrubber(['password', 'firstname', 'CamelCaseKey'], [/X\d{3}/i, 'AB\\d+']);
 
     it('should allow safe metadata', function () {
         const scrubbedData = scrubber.scrub({
@@ -103,6 +103,15 @@ describe('scrubber', function () {
         assert.nestedInclude(scrubbedData, {
             'users[1].firstname': '[REDACTED]',
         });
+    });
+    it('should redact strings via regular expression', function () {
+        const scrubbedData = scrubber.scrub({
+            level: 'info',
+            message: 'Users X391 and x910 (but not x82) provided PINs AB1 and AB492 (not AA7)',
+        });
+
+        assert.include(scrubbedData, { level: 'info' });
+        assert.include(scrubbedData, { message: 'Users [REDACTED] and [REDACTED] (but not x82) provided PINs [REDACTED] and [REDACTED] (not AA7)' });
     });
     it('should not modify the object passed to it', function () {
         const input = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->



## Description
<!--- Describe your changes in detail -->
Add `redactRegexes` option that enables replacements on each string value of provided regexes with `[REDACTED]`. Also updated the `browserslist` package to get the latest `caniuse-lite` (per package recommendation).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The AMS project wants to be able to filter sensitive information that is in string format, not in object metadata.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit test to verify various allowed regular expression scenarios.

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.
