### PR TITLE
v2.2.1: Fix injection of redaction regular expressions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qpp-shared-logger-node",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "qpp-shared-logger-node",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "UNLICENSED",
       "dependencies": {
         "morgan": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-shared-logger-node",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Common QPP logger that is shared across the different teams",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,7 +182,7 @@ class SharedLogger {
         // winston: application logger
         //
         if (logEnabled(options)) {
-            const scrubber = new Scrubber(options.redactKeys || []);
+            const scrubber = new Scrubber(options.redactKeys || [], options.redactRegexes || []);
             let formats = [
                 scrubber.format(),
                 winston.format.label({ label: options.projectSlug }),
@@ -253,7 +253,7 @@ class SharedLogger {
                     return url;
                 }
                 // redact the query parameters
-                const scrubber = new Scrubber(options.redactKeys || []);
+                const scrubber = new Scrubber(options.redactKeys || [], options.redactRegexes || []);
                 const scrubbedQuery = scrubber.scrub(req.query);
                 const scrubbedQueryParameters = Object.entries(
                     scrubbedQuery || {}

--- a/test/index.ts
+++ b/test/index.ts
@@ -4,7 +4,7 @@ const assert = require('chai').assert;
 const sinon = require('sinon');
 const fs = require('fs');
 const moment = require('moment');
-import { sharedLogger } from '../src';
+import { Options, sharedLogger } from '../src';
 import * as winston from 'winston';
 const TEST_LOG_DIR = process.env.TEST_LOG_DIR || '/tmp';
 
@@ -135,6 +135,22 @@ describe('sharedLogger', function () {
             assert.equal(
                 spy.getCall(0).lastArg,
                 '{"@message":"should be logstash","@fields":{"level":"info","label":"test"}}\n'
+            );
+        });
+
+        it('should setup redaction regexes', () => {
+            const options: Options = {
+                projectSlug: 'test',
+                logDirectory: 'console',
+                logTimestamps: false,
+                redactRegexes: [/b[a-z]/]
+            };
+            const spy = sandbox.spy(process.stdout, 'write');
+            sharedLogger.configure(options);
+            sharedLogger.logger.info('should be redacted');
+            assert.equal(
+                spy.getCall(0).lastArg,
+                '{"message":"should [REDACTED] redacted","level":"info","label":"test"}\n'
             );
         });
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Regex redactions weren't being injected into the scrubber, so nothing was working as configured. Fixed the injection and added a test to validate the fix.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The new regex feature didn't work.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added unit test.

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
