### PR TITLE
QPPA-7951 make redaction keys case insensitive

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import fs = require('fs');
 import filenames = require('./filenames');
 import { Scrubber } from './scrubber';
 import { Options } from './options';
+import { Request } from './request';
 
 function defaultLogDirByEnvironment(options: Options) {
     switch (options.environment) {
@@ -250,7 +251,7 @@ class SharedLogger {
         //
         options.accessLog = options.accessLog || {};
         if (accessLogEnabled(options)) {
-            morgan.token('url', (req) => {
+            morgan.token('url', (req: Request) => {
                 const url = req['pathname'] ?? req['baseUrl'];
                 if (!req['query'] || Object.keys(req['query']).length === 0) {
                     return url;

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,0 +1,6 @@
+import http = require('http');
+
+export interface Request extends http.IncomingMessage {
+  baseUrl: string;
+  query: string;
+}

--- a/src/scrubber.ts
+++ b/src/scrubber.ts
@@ -36,7 +36,7 @@ export class Scrubber {
         this.blacklist = [
             ...new Set([
                 ...redactKeys.map((key) => key.toLowerCase()),
-                ...defaultRedactKeys,
+                ...defaultRedactKeys.map((key) => key.toLowerCase()),
             ]),
         ];
         this.regexesBlacklist = regexesBlacklist ?? [];

--- a/test/index.ts
+++ b/test/index.ts
@@ -117,11 +117,13 @@ describe('sharedLogger', function () {
             };
             const spy = sandbox.spy(process.stdout, 'write');
             sharedLogger.configure(options);
-            sharedLogger.logger.info('should be prettyPrint');
+            sharedLogger.logger.info('should be prettyPrint', { meta: {a: 'b'}});
+
+            const expectedVal = "{\n  meta: { a: 'b' },\n  level: 'info',\n  message: 'should be prettyPrint',\n  label: 'test'\n}\n";
 
             assert.equal(
                 spy.getCall(0).lastArg,
-                "{ message: 'should be prettyPrint', level: 'info', label: 'test' }\n",
+                expectedVal,
             );
         });
 

--- a/test/scrubber.ts
+++ b/test/scrubber.ts
@@ -147,4 +147,14 @@ describe('scrubber', function () {
         assert.nestedInclude(input, { 'users[1].password': 'Password321' });
         assert.nestedInclude(input, { 'users[1].firstname': 'Jeff' });
     });
+
+    it('should redact default keys with capitalized letters', function () {
+        const scrubbedData = scrubber.scrub({
+            taxpayerIdentificationNumber: '00012345',
+        });
+
+        assert.include(scrubbedData, {
+            taxpayerIdentificationNumber: '[REDACTED]',
+        });
+    });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Make redaction keys case insensitive

## Motivation and Context
Patch a potential hole when logger dev might use capital letters in keys that should be redacted.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
